### PR TITLE
removed unused cloudflare block

### DIFF
--- a/cloudflare/cloudflare.go
+++ b/cloudflare/cloudflare.go
@@ -1,6 +1,0 @@
-package cloudflare
-
-type Cloudflare struct {
-	Domain string `json:"domain" yaml:"domain"`
-	Token  string `json:"token" yaml:"token"`
-}

--- a/cluster.go
+++ b/cluster.go
@@ -2,7 +2,6 @@ package clustertpr
 
 import (
 	"github.com/giantswarm/clustertpr/calico"
-	"github.com/giantswarm/clustertpr/cloudflare"
 	"github.com/giantswarm/clustertpr/cluster"
 	"github.com/giantswarm/clustertpr/customer"
 	"github.com/giantswarm/clustertpr/docker"
@@ -16,7 +15,6 @@ import (
 
 type Cluster struct {
 	Calico     calico.Calico         `json:"calico" yaml:"calico"`
-	Cloudflare cloudflare.Cloudflare `json:"cloudflare" yaml:"cloudflare"`
 	Cluster    cluster.Cluster       `json:"cluster" yaml:"cluster"`
 	Customer   customer.Customer     `json:"customer" yaml:"customer"`
 	Docker     docker.Docker         `json:"docker" yaml:"docker"`


### PR DESCRIPTION
Tis PR removed the unused Cloudflare config block. AFAIK this is not used at all, so lets get rid of it. 