### PR TITLE
added flannel client config

### DIFF
--- a/flannel/client/client.go
+++ b/flannel/client/client.go
@@ -1,0 +1,5 @@
+package client
+
+type Client struct {
+	SubnetLen int
+}

--- a/flannel/flannel.go
+++ b/flannel/flannel.go
@@ -1,12 +1,15 @@
 package flannel
 
 import (
+	"github.com/giantswarm/clustertpr/flannel/client"
 	"github.com/giantswarm/clustertpr/flannel/docker"
 )
 
 type Flannel struct {
 	// Backend is the Flannel backend type, e.g. vxlan.
 	Backend string `json:"backend" yaml:"backend"`
+	// Client is the block for the flannel client configuration.
+	Client client.Client `json:"client" yaml:"client"`
 	// Docker is the block for the full Docker image tag.
 	Docker docker.Docker `json:"docker" yaml:"docker"`
 	// Interface is the network interface name, e.g. bond0.3, or ens33.


### PR DESCRIPTION
This PR goes towards https://github.com/giantswarm/kvm-operator/issues/59. I realized that this is KVM specific, like the whole flannel configuration in here, and probably other things. We have several issues in the operator board concerned about this. So we will clean this up later. I will probably do it after my vacation. 

See

- https://github.com/giantswarm/kvm-operator/issues/64
- https://github.com/giantswarm/kvm-operator/issues/65

For now I just go with this to make the KVM guest cluster work again. 