### PR TITLE
Add API domains for Calico and Workers

### DIFF
--- a/calico/calico.go
+++ b/calico/calico.go
@@ -1,7 +1,10 @@
 package calico
 
 type Calico struct {
-	CIDR   string `json:"cidr" yaml:"cidr"`
+	CIDR string `json:"cidr" yaml:"cidr"`
+	// Domain is the API domain for Calico, e.g.
+	// calico.<cluster-id>.g8s.fra-1.giantswarm.io.
+	Domain string `json:"domain" yaml:"domain"`
 	MTU    string `json:"mtu" yaml:"mtu"`
 	Subnet string `json:"subnet" yaml:"subnet"`
 }

--- a/etcd/etcd.go
+++ b/etcd/etcd.go
@@ -1,6 +1,8 @@
 package etcd
 
 type Etcd struct {
+	// Domain is the API domain for etcd, e.g.
+	// etcd.<cluster-id>.g8s.fra-1.giantswarm.io.
 	Domain string `json:"domain" yaml:"domain"`
 	Port   int    `json:"port" yaml:"port"`
 	Prefix string `json:"prefix" yaml:"prefix"`

--- a/kubernetes/kubelet/kubelet.go
+++ b/kubernetes/kubelet/kubelet.go
@@ -6,7 +6,10 @@ type Kubelet struct {
 	// server plus the service name of the API server. The addition is important
 	// to make kubelets able to connect to the API servers.
 	AltNames string `json:"altNames" yaml:"altNames"`
-	Labels   string `json:"labels" yaml:"labels"`
+	// Domain is the API domain for the Kubernetes worker nodes, e.g.
+	// worker.<cluster-id>.g8s.fra-1.giantswarm.io.
+	Domain string `json:"domain" yaml:"domain"`
+	Labels string `json:"labels" yaml:"labels"`
 	// Port is the kubelet service port, used in the Kubernetes service definition
 	// of the worker nodes.
 	Port int `json:"port" yaml:"port"`


### PR DESCRIPTION
Implements giantswarm/giantswarm#1304

This PR adds the API domains for calico and worker nodes. The TPR already has the api and etcd domains. These are used in kubernetesd as the common names when creating the certificate TPOs.