### PR TITLE
calico: Change the type of MTU from string to int

### DIFF
--- a/calico/calico.go
+++ b/calico/calico.go
@@ -1,10 +1,10 @@
 package calico
 
 type Calico struct {
-	CIDR string `json:"cidr" yaml:"cidr"`
+	CIDR int `json:"cidr" yaml:"cidr"`
 	// Domain is the API domain for Calico, e.g.
 	// calico.<cluster-id>.g8s.fra-1.giantswarm.io.
 	Domain string `json:"domain" yaml:"domain"`
-	MTU    string `json:"mtu" yaml:"mtu"`
+	MTU    int    `json:"mtu" yaml:"mtu"`
 	Subnet string `json:"subnet" yaml:"subnet"`
 }


### PR DESCRIPTION
MTU is always a numeric value, there is no need to allow strings there.