### PR TITLE
Add ingress to kubernetes

### DIFF
--- a/kubernetes/ingress/ingress.go
+++ b/kubernetes/ingress/ingress.go
@@ -1,8 +1,8 @@
 package ingress
 
-type Ingress struct {
-	// Domain is the external domain of the Ingress running in the Kubernetes cluster, e.g.
-	// <cluster-id>.fra-1.gigantic.io.
+type IngressController struct {
+	// Domain is the external domain of the Ingress controller running in the
+	// Kubernetes cluster, e.g. <cluster-id>.fra-1.gigantic.io.
 	Domain string `json:"domain" yaml:"domain"`
 	// InsecurePort is the HTTP node port of the Ingress.
 	InsecurePort int `json:"insecurePort" yaml:"insecurePort"`

--- a/kubernetes/ingress/ingress.go
+++ b/kubernetes/ingress/ingress.go
@@ -1,0 +1,11 @@
+package ingress
+
+type Ingress struct {
+	// Domain is the external domain of the Ingress running in the Kubernetes cluster, e.g.
+	// <cluster-id>.fra-1.gigantic.io.
+	Domain string `json:"domain" yaml:"domain"`
+	// InsecurePort is the HTTP node port of the Ingress.
+	InsecurePort int `json:"insecurePort" yaml:"insecurePort"`
+	// SecurePort is the HTTPS node port of the Ingress.
+	SecurePort int `json:"securePort" yaml:"securePort"`
+}

--- a/kubernetes/ingress/ingress.go
+++ b/kubernetes/ingress/ingress.go
@@ -1,11 +1,11 @@
 package ingress
 
 type IngressController struct {
-	// Domain is the external domain of the Ingress controller running in the
+	// Domain is the external domain of the Ingress Controller running in the
 	// Kubernetes cluster, e.g. <cluster-id>.fra-1.gigantic.io.
 	Domain string `json:"domain" yaml:"domain"`
-	// InsecurePort is the HTTP node port of the Ingress.
+	// InsecurePort is the HTTP node port of the Ingress Controller.
 	InsecurePort int `json:"insecurePort" yaml:"insecurePort"`
-	// SecurePort is the HTTPS node port of the Ingress.
+	// SecurePort is the HTTPS node port of the Ingress Controller.
 	SecurePort int `json:"securePort" yaml:"securePort"`
 }

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -4,6 +4,7 @@ import (
 	"github.com/giantswarm/clustertpr/kubernetes/api"
 	"github.com/giantswarm/clustertpr/kubernetes/dns"
 	"github.com/giantswarm/clustertpr/kubernetes/hyperkube"
+	"github.com/giantswarm/clustertpr/kubernetes/ingress"
 	"github.com/giantswarm/clustertpr/kubernetes/kubelet"
 )
 
@@ -14,5 +15,6 @@ type Kubernetes struct {
 	// g8s.fra-1.giantswarm.io.
 	Domain    string              `json:"domain" yaml:"domain"`
 	Hyperkube hyperkube.Hyperkube `json:"hyperkube" yaml:"hyperkube"`
+	Ingress   ingress.Ingress     `json:"ingress" yaml:"ingress"`
 	Kubelet   kubelet.Kubelet     `json:"kubelet" yaml:"kubelet"`
 }

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -13,8 +13,8 @@ type Kubernetes struct {
 	DNS dns.DNS `json:"dns" yaml:"dns"`
 	// Domain is the base domain of the Kubernetes cluster, e.g.
 	// g8s.fra-1.giantswarm.io.
-	Domain    string                    `json:"domain" yaml:"domain"`
-	Hyperkube hyperkube.Hyperkube       `json:"hyperkube" yaml:"hyperkube"`
-	Ingress   ingress.IngressController `json:"ingress" yaml:"ingress"`
-	Kubelet   kubelet.Kubelet           `json:"kubelet" yaml:"kubelet"`
+	Domain            string                    `json:"domain" yaml:"domain"`
+	Hyperkube         hyperkube.Hyperkube       `json:"hyperkube" yaml:"hyperkube"`
+	IngressController ingress.IngressController `json:"ingressController" yaml:"ingressController"`
+	Kubelet           kubelet.Kubelet           `json:"kubelet" yaml:"kubelet"`
 }

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -13,8 +13,8 @@ type Kubernetes struct {
 	DNS dns.DNS `json:"dns" yaml:"dns"`
 	// Domain is the base domain of the Kubernetes cluster, e.g.
 	// g8s.fra-1.giantswarm.io.
-	Domain    string              `json:"domain" yaml:"domain"`
-	Hyperkube hyperkube.Hyperkube `json:"hyperkube" yaml:"hyperkube"`
-	Ingress   ingress.Ingress     `json:"ingress" yaml:"ingress"`
-	Kubelet   kubelet.Kubelet     `json:"kubelet" yaml:"kubelet"`
+	Domain    string                    `json:"domain" yaml:"domain"`
+	Hyperkube hyperkube.Hyperkube       `json:"hyperkube" yaml:"hyperkube"`
+	Ingress   ingress.IngressController `json:"ingress" yaml:"ingress"`
+	Kubelet   kubelet.Kubelet           `json:"kubelet" yaml:"kubelet"`
 }


### PR DESCRIPTION
Towards giantswarm/giantswarm#1381

This PR added an Ingress section to Kubernetes. It stores the external domain and http / https ports. On AWS these will be used to create an ELB in front of the Ingress controller running in the guest cluster. The gigantic.io domain is used because the Ingress is serving customer data.
