### PR TITLE
aligned all JSON/YAML tags to be the same

### DIFF
--- a/flannel/client/client.go
+++ b/flannel/client/client.go
@@ -1,5 +1,5 @@
 package client
 
 type Client struct {
-	SubnetLen int
+	SubnetLen int `json:"subnetLen" yaml:"subnetLen"`
 }

--- a/flannel/docker/docker.go
+++ b/flannel/docker/docker.go
@@ -1,5 +1,5 @@
 package docker
 
 type Docker struct {
-	Image string
+	Image string `json:"image" yaml:"image"`
 }

--- a/operator/certctl/certctl.go
+++ b/operator/certctl/certctl.go
@@ -5,5 +5,5 @@ import (
 )
 
 type Certctl struct {
-	Docker docker.Docker
+	Docker docker.Docker `json:"docker" yaml:"docker"`
 }

--- a/operator/certctl/docker/docker.go
+++ b/operator/certctl/docker/docker.go
@@ -1,5 +1,5 @@
 package docker
 
 type Docker struct {
-	Image string
+	Image string `json:"image" yaml:"image"`
 }

--- a/operator/k8svm/docker/docker.go
+++ b/operator/k8svm/docker/docker.go
@@ -1,5 +1,5 @@
 package docker
 
 type Docker struct {
-	Image string
+	Image string `json:"image" yaml:"image"`
 }

--- a/operator/k8svm/k8svm.go
+++ b/operator/k8svm/k8svm.go
@@ -5,5 +5,5 @@ import (
 )
 
 type K8sVM struct {
-	Docker docker.Docker
+	Docker docker.Docker `json:"docker" yaml:"docker"`
 }

--- a/operator/kubectl/googleapi/googleapi.go
+++ b/operator/kubectl/googleapi/googleapi.go
@@ -1,5 +1,5 @@
 package googleapi
 
 type GoogleAPI struct {
-	URL string
+	URL string `json:"url" yaml:"url"`
 }

--- a/operator/kubectl/kubectl.go
+++ b/operator/kubectl/kubectl.go
@@ -5,5 +5,5 @@ import (
 )
 
 type Kubectl struct {
-	GoogleAPI googleapi.GoogleAPI
+	GoogleAPI googleapi.GoogleAPI `json:"googleAPI" yaml:"googleAPI"`
 }

--- a/operator/networksetup/docker/docker.go
+++ b/operator/networksetup/docker/docker.go
@@ -1,5 +1,5 @@
 package docker
 
 type Docker struct {
-	Image string
+	Image string `json:"image" yaml:"image"`
 }

--- a/operator/networksetup/networksetup.go
+++ b/operator/networksetup/networksetup.go
@@ -5,5 +5,5 @@ import (
 )
 
 type NetworkSetup struct {
-	Docker docker.Docker
+	Docker docker.Docker `json:"docker" yaml:"docker"`
 }

--- a/operator/operator.go
+++ b/operator/operator.go
@@ -8,8 +8,8 @@ import (
 )
 
 type Operator struct {
-	Certctl      certctl.Certctl
-	K8sVM        k8svm.K8sVM
-	Kubectl      kubectl.Kubectl
-	NetworkSetup networksetup.NetworkSetup
+	Certctl      certctl.Certctl           `json:"certctl" yaml:"certctl"`
+	K8sVM        k8svm.K8sVM               `json:"k8sVM" yaml:"k8sVM"`
+	Kubectl      kubectl.Kubectl           `json:"kubectl" yaml:"kubectl"`
+	NetworkSetup networksetup.NetworkSetup `json:"networkSetup" yaml:"networkSetup"`
 }


### PR DESCRIPTION
We decided to align all tags to prevent failures and confusion when our systems are working together. This should ease the understanding and enhances stability. Lets stick to this convention. 