### PR TITLE
NetworkSetup docker image

### DIFF
--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -6,6 +6,7 @@ import (
 	"github.com/giantswarm/clustertpr/kubernetes/hyperkube"
 	"github.com/giantswarm/clustertpr/kubernetes/ingress"
 	"github.com/giantswarm/clustertpr/kubernetes/kubelet"
+	"github.com/giantswarm/clustertpr/kubernetes/networksetup"
 )
 
 type Kubernetes struct {

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -17,4 +17,5 @@ type Kubernetes struct {
 	Hyperkube         hyperkube.Hyperkube       `json:"hyperkube" yaml:"hyperkube"`
 	IngressController ingress.IngressController `json:"ingressController" yaml:"ingressController"`
 	Kubelet           kubelet.Kubelet           `json:"kubelet" yaml:"kubelet"`
+	NetworkSetup      networksetup.NetworkSetup `json:"networkSetup" yaml:"networkSetup"`
 }

--- a/kubernetes/networksetup/docker/docker.go
+++ b/kubernetes/networksetup/docker/docker.go
@@ -1,0 +1,7 @@
+package docker
+
+type Docker struct {
+	// Image is the full qualified docker image,
+	// e.g. giantswarm/k8s-setup-network-environment:ba2b57155d859a1fc5d378c2a09a77d7c2c755ed
+	Image string `json:"image" yaml:"image"`
+}

--- a/kubernetes/networksetup/networksetup.go
+++ b/kubernetes/networksetup/networksetup.go
@@ -1,0 +1,9 @@
+package networksetup
+
+import (
+	"github.com/giantswarm/clustertpr/kubernetes/networksetup/docker"
+)
+
+type NetworkSetup struct {
+	Docker docker.Docker `json:"docker" yaml:"docker"`
+}


### PR DESCRIPTION
Towards giantswarm/k8scloudconfig#83

This PR adds the NetworkSetup docker image to a new NetworkSetup block in Kubernetes. It was previously in the Operator block. This is because the rest of the Operator block is KVM specific and has moved to kvmtpr.