### PR TITLE
replaced node.Hostname with node.ID

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -1,7 +1,7 @@
 package node
 
 type Node struct {
-	Hostname string `json:"hostname" yaml:"hostname"`
-	Memory   string `json:"memory" yaml:"memory"`
-	CPUs     int    `json:"cpus" yaml:"cpus"`
+	CPUs   int    `json:"cpus" yaml:"cpus"`
+	ID     string `json:"id" yaml:"id"`
+	Memory string `json:"memory" yaml:"memory"`
 }


### PR DESCRIPTION
The hostname is set provider specifically. It does not make that much sense to set it. Not all providers allow this anyway. We want to have something to identify nodes though. We use the ID property for this. 