### PR TITLE
Unify domain field

### DIFF
--- a/calico/calico.go
+++ b/calico/calico.go
@@ -1,10 +1,7 @@
 package calico
 
 type Calico struct {
-	CIDR int `json:"cidr" yaml:"cidr"`
-	// Domain is the API domain for Calico, e.g.
-	// calico.<cluster-id>.g8s.fra-1.giantswarm.io.
-	Domain string `json:"domain" yaml:"domain"`
+	CIDR   int    `json:"cidr" yaml:"cidr"`
 	MTU    int    `json:"mtu" yaml:"mtu"`
 	Subnet string `json:"subnet" yaml:"subnet"`
 }

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -2,4 +2,7 @@ package cluster
 
 type Cluster struct {
 	ID string `json:"id" yaml:"id"`
+	// Domain is the base domain for records in the cluster, e.g.
+	// <cluster-id>.g8s.fra-1.giantswarm.io.
+	Domain string `json:"domain" yaml:"domain"`
 }

--- a/etcd/etcd.go
+++ b/etcd/etcd.go
@@ -3,9 +3,6 @@ package etcd
 type Etcd struct {
 	// AltNames is the alternative names used to generate certificates for Etcd.
 	AltNames string `json:"altNames" yaml:"altNames"`
-	// Domain is the API domain for etcd, e.g.
-	// etcd.<cluster-id>.g8s.fra-1.giantswarm.io.
-	Domain string `json:"domain" yaml:"domain"`
-	Port   int    `json:"port" yaml:"port"`
-	Prefix string `json:"prefix" yaml:"prefix"`
+	Port     int    `json:"port" yaml:"port"`
+	Prefix   string `json:"prefix" yaml:"prefix"`
 }

--- a/kubernetes/api/api.go
+++ b/kubernetes/api/api.go
@@ -11,9 +11,6 @@ type API struct {
 	// ClusterIpRange is the value for command line flag
 	// --service-cluster-ip-range of the Kubernetes API server, e.g. 10.0.3.0/24.
 	ClusterIPRange string `json:"clusterIPRange" yaml:"clusterIPRange"`
-	// Domain is the API domain of the Kubernetes cluster, e.g.
-	// api.<cluster-id>.g8s.fra-1.giantswarm.io.
-	Domain string `json:"domain" yaml:"domain"`
 	// IP is the Kubernetes API IP, e.g. 172.29.0.1.
 	IP           net.IP `json:"ip" yaml:"ip"`
 	InsecurePort int    `json:"insecurePort" yaml:"insecurePort"`

--- a/kubernetes/ingress/ingress.go
+++ b/kubernetes/ingress/ingress.go
@@ -1,9 +1,6 @@
 package ingress
 
 type IngressController struct {
-	// Domain is the external domain of the Ingress Controller running in the
-	// Kubernetes cluster, e.g. <cluster-id>.fra-1.gigantic.io.
-	Domain string `json:"domain" yaml:"domain"`
 	// InsecurePort is the HTTP node port of the Ingress Controller.
 	InsecurePort int `json:"insecurePort" yaml:"insecurePort"`
 	// SecurePort is the HTTPS node port of the Ingress Controller.

--- a/kubernetes/kubelet/kubelet.go
+++ b/kubernetes/kubelet/kubelet.go
@@ -6,10 +6,7 @@ type Kubelet struct {
 	// server plus the service name of the API server. The addition is important
 	// to make kubelets able to connect to the API servers.
 	AltNames string `json:"altNames" yaml:"altNames"`
-	// Domain is the API domain for the Kubernetes worker nodes, e.g.
-	// worker.<cluster-id>.g8s.fra-1.giantswarm.io.
-	Domain string `json:"domain" yaml:"domain"`
-	Labels string `json:"labels" yaml:"labels"`
+	Labels   string `json:"labels" yaml:"labels"`
 	// Port is the kubelet service port, used in the Kubernetes service definition
 	// of the worker nodes.
 	Port int `json:"port" yaml:"port"`

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -10,11 +10,8 @@ import (
 )
 
 type Kubernetes struct {
-	API api.API `json:"api" yaml:"api"`
-	DNS dns.DNS `json:"dns" yaml:"dns"`
-	// Domain is the base domain of the Kubernetes cluster, e.g.
-	// g8s.fra-1.giantswarm.io.
-	Domain            string                    `json:"domain" yaml:"domain"`
+	API               api.API                   `json:"api" yaml:"api"`
+	DNS               dns.DNS                   `json:"dns" yaml:"dns"`
 	Hyperkube         hyperkube.Hyperkube       `json:"hyperkube" yaml:"hyperkube"`
 	IngressController ingress.IngressController `json:"ingressController" yaml:"ingressController"`
 	Kubelet           kubelet.Kubelet           `json:"kubelet" yaml:"kubelet"`


### PR DESCRIPTION
We assume that every record will look like:

*.<cluster-id>.giantswarm.io
aws.<cluster-id>.giantswarm.io
api.<cluster-id>.giantswarm.io
ingress.<cluster-id>.giantswarm.io

Since we also want to have wildcard records, it's better to define the domain once than requiring to define the domain for each component.

Ref #253