### PR TITLE
ingress: Add wildcardDomain field

### DIFF
--- a/kubernetes/ingress/ingress.go
+++ b/kubernetes/ingress/ingress.go
@@ -4,6 +4,10 @@ type IngressController struct {
 	// Domain is the external domain of the Ingress Controller running in the
 	// Kubernetes cluster, e.g. <cluster-id>.fra-1.gigantic.io.
 	Domain string `json:"domain" yaml:"domain"`
+	// Wildcard domain is the external domain that is a CNAME to the ingress
+	// domain in Kubernetes cluster, e.g. *.<cluster-id>.fra-1.gigantic.io.
+	// It will allow to use ingress without creating DNS records.
+	WildcardDomain string `json:"wildcardDomain" yaml:"wildcardDomain"`
 	// InsecurePort is the HTTP node port of the Ingress Controller.
 	InsecurePort int `json:"insecurePort" yaml:"insecurePort"`
 	// SecurePort is the HTTPS node port of the Ingress Controller.


### PR DESCRIPTION
We need to provide a wildcard record which will be used for ingress controller. This wildcard will be a CNAME to ingress domain, which will allow to use ingress without creating DNS records.

Ref giantswarm/aws-operator#253