### PR TITLE
add kubectl docker image to clustertpr

### DIFF
--- a/kubernetes/kubectl/docker/docker.go
+++ b/kubernetes/kubectl/docker/docker.go
@@ -1,0 +1,5 @@
+package docker
+
+type Docker struct {
+	Image string `json:"image" yaml:"image"`
+}

--- a/kubernetes/kubectl/docker/docker.go
+++ b/kubernetes/kubectl/docker/docker.go
@@ -1,5 +1,7 @@
 package docker
 
 type Docker struct {
+	// Image is the full qualified docker image,
+	// e.g.quay.io/giantswarm/docker-kubectl:a121f8d14cd14567abc2ec20a7258be9d70ecb45
 	Image string `json:"image" yaml:"image"`
 }

--- a/kubernetes/kubectl/kubectl.go
+++ b/kubernetes/kubectl/kubectl.go
@@ -1,0 +1,7 @@
+package kubectl
+
+import "github.com/giantswarm/clustertpr/kubernetes/kubectl/docker"
+
+type Kubectl struct {
+	Docker docker.Docker `json:"docker" yaml:"docker"`
+}

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -18,8 +18,8 @@ type Kubernetes struct {
 	// g8s.fra-1.giantswarm.io.
 	Domain            string                    `json:"domain" yaml:"domain"`
 	Hyperkube         hyperkube.Hyperkube       `json:"hyperkube" yaml:"hyperkube"`
-	Kubectl           kubectl.Kubectl           `json:"kubectl" yaml:"kubectl"`
 	IngressController ingress.IngressController `json:"ingressController" yaml:"ingressController"`
+	Kubectl           kubectl.Kubectl           `json:"kubectl" yaml:"kubectl"`
 	Kubelet           kubelet.Kubelet           `json:"kubelet" yaml:"kubelet"`
 	NetworkSetup      networksetup.NetworkSetup `json:"networkSetup" yaml:"networkSetup"`
 	SSH               ssh.SSH                   `json:"ssh" yaml:"ssh"`

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -5,6 +5,7 @@ import (
 	"github.com/giantswarm/clustertpr/kubernetes/dns"
 	"github.com/giantswarm/clustertpr/kubernetes/hyperkube"
 	"github.com/giantswarm/clustertpr/kubernetes/ingress"
+	"github.com/giantswarm/clustertpr/kubernetes/kubectl"
 	"github.com/giantswarm/clustertpr/kubernetes/kubelet"
 	"github.com/giantswarm/clustertpr/kubernetes/networksetup"
 	"github.com/giantswarm/clustertpr/kubernetes/ssh"
@@ -17,6 +18,7 @@ type Kubernetes struct {
 	// g8s.fra-1.giantswarm.io.
 	Domain            string                    `json:"domain" yaml:"domain"`
 	Hyperkube         hyperkube.Hyperkube       `json:"hyperkube" yaml:"hyperkube"`
+	Kubectl           kubectl.Kubectl           `json:"kubectl" yaml:"kubectl"`
 	IngressController ingress.IngressController `json:"ingressController" yaml:"ingressController"`
 	Kubelet           kubelet.Kubelet           `json:"kubelet" yaml:"kubelet"`
 	NetworkSetup      networksetup.NetworkSetup `json:"networkSetup" yaml:"networkSetup"`


### PR DESCRIPTION
it will be used by both KVM and AWS clusters.

Not sure if/why we need to have duplicate `docker` sub-packages under `hypervisor/`, `kubectl/`, `networksetup`, but I followed the project structure and added one too.

Happy to fix this if that's not necessary. 

Towards https://github.com/giantswarm/k8scloudconfig/issues/136