### PR TITLE
Add the ingress controller docker image

### DIFF
--- a/spec/kubernetes/ingress.go
+++ b/spec/kubernetes/ingress.go
@@ -1,6 +1,10 @@
 package kubernetes
 
+import "github.com/giantswarm/clustertpr/spec/kubernetes/ingress"
+
 type IngressController struct {
+	// Docker is the docker image for the Ingress Controller.
+	Docker ingress.Docker `json:"docker" yaml:"docker"`
 	// Domain is the external domain of the Ingress Controller running in the
 	// Kubernetes cluster, e.g. <cluster-id>.fra-1.gigantic.io.
 	Domain string `json:"domain" yaml:"domain"`

--- a/spec/kubernetes/ingress/docker.go
+++ b/spec/kubernetes/ingress/docker.go
@@ -1,0 +1,7 @@
+package ingress
+
+type Docker struct {
+	// Image is the full qualified docker image,
+	// e.g. quay.io/giantswarm/nginx-ingress-controller/0.9.0-beta.11
+	Image string `json:"image" yaml:"image"`
+}


### PR DESCRIPTION
Towards giantswarm/giantswarm#1695

This PR adds the fully qualified Ingress Controller docker image to the IngressController block. This is so we use a retagged image and can replace the hardcoded image in k8scloudconfig.