### PR TITLE
remove deprecated fields

### DIFF
--- a/spec/docker.go
+++ b/spec/docker.go
@@ -3,7 +3,5 @@ package spec
 import "github.com/giantswarm/clustertpr/spec/docker"
 
 type Docker struct {
-	Daemon         docker.Daemon   `json:"daemon" yaml:"daemon"`
-	ImageNamespace string          `json:"imageNamespace" yaml:"imageNamespace"`
-	Registry       docker.Registry `json:"registry" yaml:"registry"`
+	Daemon docker.Daemon `json:"daemon" yaml:"daemon"`
 }

--- a/spec/docker/registry.go
+++ b/spec/docker/registry.go
@@ -1,5 +1,0 @@
-package docker
-
-type Registry struct {
-	Endpoint string `json:"endpoint" yaml:"endpoint"`
-}


### PR DESCRIPTION
The image namespace and registry endpoint for Docker are not used anywhere anymore. In Kubernetesd these flags are also marked as deprecated. I think it is safe to get rid of them now. 